### PR TITLE
Stop the explorer scrolling the page on full page loads

### DIFF
--- a/quartz/components/scripts/explorer.inline.ts
+++ b/quartz/components/scripts/explorer.inline.ts
@@ -224,7 +224,13 @@ async function setupExplorer(currentSlug: FullSlug) {
       // try to scroll to the active element if it exists
       const activeElement = explorerUl.querySelector(".active")
       if (activeElement) {
-        activeElement.scrollIntoView({ behavior: "smooth" })
+        // scroll the explorer list itself rather than calling scrollIntoView, which
+        // also scrolls the page down on a full page load
+        const activeRect = activeElement.getBoundingClientRect()
+        const explorerRect = explorerUl.getBoundingClientRect()
+        if (activeRect.top < explorerRect.top || activeRect.bottom > explorerRect.bottom) {
+          explorerUl.scrollTop += activeRect.top - explorerRect.top
+        }
       }
     }
 


### PR DESCRIPTION
On a full page load there is no `explorerScrollTop` in sessionStorage (it is only written by the `prenav` handler during SPA navigation), so the explorer falls into the `activeElement.scrollIntoView({behavior: "smooth"})` branch. `scrollIntoView` scrolls every scrollable ancestor including the window, so the page glides down to roughly the first section. Navigating via the sidebar does not do this, because the sessionStorage branch is taken instead.

Scroll the explorer list directly instead, and only when the active item is actually out of view.