### PR TITLE
Update GitHub Actions to current majors

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -7,7 +7,7 @@ jobs:
   update-submodule:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -17,7 +17,7 @@ jobs:
           git submodule update --remote content
           
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update submodule ${{ github.event.client_payload.submodule }}"


### PR DESCRIPTION
actions/checkout v3 to v7 and peter-evans/create-pull-request v5 to v8. Supersedes the Dependabot PR that targeted checkout v6.